### PR TITLE
ci: Add prod and qa build seperate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,12 +118,8 @@ workflows:
           context:
             - connect-team
       - approve_semantic_release:
+          <<: *filter_only_main
           type: approval
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              only: /.*/
       - semantic_release:
           <<: *filter_only_main
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,7 @@ workflows:
           <<: *filter_only_main
           requires:
             - test
+            - build_prod
             - approve_semantic_release
           context:
             - semantic-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,8 @@ anchors:
     context:
       - connect-team
     requires:
-      - build
+      - build_qa
+      - build_prod
       - test
   filter_only_main: &filter_only_main
     filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ workflows:
             tags:
               only: /.*/
             branches:
-              ignore: /.*/
+              only: main
       - test:
           requires:
             - build_qa

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,22 @@ executors:
       - image: cimg/python:3.11.3-browsers
 
 jobs:
-  build:
+  build_qa:
+    executor: node
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: yarn
+      - run:
+          name: Building App for QA env
+          command: |
+              yarn build:qa
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+            - build/
+  build_prod:
     executor: node
     steps:
       - checkout
@@ -50,12 +65,9 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
+            - . 
             - build/
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
-  semantic_release:
+ semantic_release:
     executor: semantic-release/default
     steps:
       - checkout
@@ -89,13 +101,19 @@ workflows:
   version: 2
   build-test-deploy:
     jobs:
-      - build:
+      - build_qa:
           filters:
             branches:
               only: /.*/
+      - build_prod:
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
       - test:
           requires:
-            - build
+            - build_qa
           context:
             - connect-team
       - approve_semantic_release:
@@ -133,6 +151,7 @@ workflows:
           distribution_id: E17P53GJGRBTBG
           aws_iam_web_identity_role_arn: $WEB_IDENTITY_ROLE_ARN_PROD
           requires:
+            - build_prod
             - approve_deploy_to_prod
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,6 @@ anchors:
     local: build/
     context:
       - connect-team
-    requires:
-      - build_qa
-      - build_prod
-      - test
   filter_only_main: &filter_only_main
     filters:
       branches:
@@ -135,6 +131,9 @@ workflows:
           bucket_name: ts-connect-qa-trustedshops-app
           distribution_id: E2HC1Y83IARISC
           aws_iam_web_identity_role_arn: $WEB_IDENTITY_ROLE_ARN_QA
+          requires:
+            - build_qa
+            - test
       - approve_deploy_to_prod:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
           paths:
             - . 
             - build/
- semantic_release:
+  semantic_release:
     executor: semantic-release/default
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,13 +68,9 @@ jobs:
     executor: semantic-release/default
     steps:
       - checkout
-      - node/install-packages:
-          pkg-manager: yarn
-      - run:
-          name: Build prod version of connector
-          command: |
-            yarn build
       - semantic-release/install
+      - attach_workspace:
+          at: .
       - semantic-release/execute
   test:
     executor: python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,9 @@ jobs:
           pkg-manager: yarn
       - deterministic-zip/install
       - run:
-          name: Building App for QA env
+          name: Building App for PROD env and release
           command: |
-              yarn build:qa
+              yarn build
       - deterministic-zip/zip:
           source: build/
           target: build/connector.zip


### PR DESCRIPTION
- Make qa and prod build more explicit
- fix missing build step for prod deployment
- use prod build for semantic-release instead of rebuilding in job