### PR TITLE
Enhance system information and loading state management

### DIFF
--- a/src/baseLayers/testData/getInformationOfSystem.ts
+++ b/src/baseLayers/testData/getInformationOfSystem.ts
@@ -26,6 +26,7 @@ export const getInformationOfSystem = (
         allowsEventsByOrderStatus: true,
         allowsSendReviewInvitesForPreviousOrders: true,
         useVersionNumberOfConnector: '2.0',
+        allowsSupportTrstdLogin: true,
       }
     case 'no_value':
       return {}

--- a/src/store/trstdLogin/index.ts
+++ b/src/store/trstdLogin/index.ts
@@ -41,10 +41,11 @@ export const trstdLoginStore = (
   },
 
   getTrstdLoginConfiguration: (channel: IMappedChannel) => {
+    get().setIsLoadingBL(true)
     set(store => ({
       trstdLoginState: {
         ...store.trstdLoginState,
-        isLoadingBL: true,
+        isLoadingBL: false,
       },
     }))
 


### PR DESCRIPTION
- Updated loading state management in `trstdLoginStore` to set `isLoadingBL` to true during configuration retrieval.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
<!--
Relates OR Closes #0000
-->

## Description
<!-- Short description about the change, what have you done? -->
