### PR TITLE
Refactor trstdLoginStore configuration handling

### DIFF
--- a/src/store/trstdLogin/index.ts
+++ b/src/store/trstdLogin/index.ts
@@ -113,32 +113,37 @@ export const trstdLoginStore = (
     }))
 
     try {
-      const response = await postTrstdLoginConfiguration(info, token as string, [
-        {
-          channelId: selectedShopChannels.eTrustedChannelRef,
-          trstdLoginEnabled: enabled,
-        },
-      ])
+      let integrationId = ''
+      let trstdLoginEnabled = enabled
 
-      if (response.error) {
-        get().addInToastList({
-          event: 'TRSTD_LOGIN_CONFIGURATION',
-          text: response.error,
-          status: 'error',
-          errorText: response.error,
-          type: 'save',
-        })
-        set(store => ({
-          trstdLoginState: {
-            ...store.trstdLoginState,
-            isLoadingBL: false,
+      if (enabled) {
+        const response = await postTrstdLoginConfiguration(info, token as string, [
+          {
+            channelId: selectedShopChannels.eTrustedChannelRef,
+            trstdLoginEnabled: enabled,
           },
-        }))
-        return
-      }
+        ])
 
-      const trstdLoginEnabled = response.trstdLoginEnabled ?? enabled
-      const integrationId = response.integrationId || ''
+        if (response.error) {
+          get().addInToastList({
+            event: 'TRSTD_LOGIN_CONFIGURATION',
+            text: response.error,
+            status: 'error',
+            errorText: response.error,
+            type: 'save',
+          })
+          set(store => ({
+            trstdLoginState: {
+              ...store.trstdLoginState,
+              isLoadingBL: false,
+            },
+          }))
+          return
+        }
+
+        trstdLoginEnabled = response.trstdLoginEnabled ?? enabled
+        integrationId = response.integrationId || ''
+      }
 
       const currentData = get().trstdLoginState.trstdLoginData
       const currentConfig = currentData.configuration


### PR DESCRIPTION
- Updated the logic in `trstdLoginStore` to conditionally post the login configuration only when enabled, improving error handling and state management.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
<!--
Relates OR Closes #0000
-->

## Description
<!-- Short description about the change, what have you done? -->
