### PR TITLE
Refactor state handling in TrustSignalsActivationModal

### DIFF
--- a/src/modules/dashboard/trustSignalsActivationModal.tsx
+++ b/src/modules/dashboard/trustSignalsActivationModal.tsx
@@ -40,8 +40,9 @@ const TrustSignalsActivationModal: FC<Props> = ({ showModal, onClose, phrasesByK
 
     for (const channel of mappedChannels) {
       try {
+        const { trstdLoginState: _trstdLoginState, ...stateWithoutTrstdLogin } = allState
         const channelAllState: Record<string, unknown> = {
-          ...allState,
+          ...stateWithoutTrstdLogin,
           channelState: {
             ...allState.channelState,
             selectedShopChannels: channel,


### PR DESCRIPTION
- Updated the state management logic to exclude `trstdLoginState` from `allState`, improving clarity and reducing unnecessary data in the channel state.
- Enhanced the overall structure of the component for better maintainability.

These changes contribute to a more efficient and streamlined TrustSignalsActivationModal.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
<!--
Relates OR Closes #0000
-->

## Description
<!-- Short description about the change, what have you done? -->
