### PR TITLE
feat: add support for Shoper-specific login action phrase

### DIFF
--- a/src/locales/keys.ts
+++ b/src/locales/keys.ts
@@ -103,6 +103,7 @@ const PHRASES_TRSTD_LOGIN_KEYS: ITRSTD_LOGIN_KEYS = {
   application_trstd_login_automatic_placement_mobile: 'application.trstd_login.automatic_placement.mobile',
   application_trstd_login_automatic_placement_desktop: 'application.trstd_login.automatic_placement.desktop',
   application_trstd_login_action_required: 'application.trstd_login.action_required',
+  application_trstd_login_action_required_shoper: 'application.trstd_login.action_required_shoper',
   application_trstd_login_about_title: 'application.trstd_login.about.title',
   application_trstd_login_about_description: 'application.trstd_login.about.description',
   application_trstd_login_about_learnMore: 'application.trstd_login.about.learnMore',
@@ -119,8 +120,7 @@ const PHRASES_TRUSTBADGE_KEYS: ITRUSTBADGE_KEYS = {
   application_trustbadge_subtitel: 'application.trustbadge.subtitel',
   application_trustbadge_description: 'application.trustbadge.description',
   application_trustbadge_placement_desktop: 'application.trustbadge.placement.desktop',
-  application_trustbadge_placement_inputDescription:
-    'application.trustbadge.placement.inputDescription',
+  application_trustbadge_placement_inputDescription: 'application.trustbadge.placement.inputDescription',
   application_trustbadge_placement_pixels: 'application.trustbadge.placement.pixels',
   application_trustbadge_placement_mobile: 'application.trustbadge.placement.mobile',
   application_trustbadge_placement_center: 'application.trustbadge.placement.center',

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -410,6 +410,7 @@ export type ITRSTD_LOGIN_KEYS = {
   application_trstd_login_automatic_placement_mobile: string
   application_trstd_login_automatic_placement_desktop: string
   application_trstd_login_action_required: string
+  application_trstd_login_action_required_shoper: string
   application_trstd_login_about_title: string
   application_trstd_login_about_description: string
   application_trstd_login_about_learnMore: string

--- a/src/modules/dashboard/tabTrstdLogin/index.tsx
+++ b/src/modules/dashboard/tabTrstdLogin/index.tsx
@@ -101,8 +101,10 @@ const TrstdLoginTab: FC<TabProps> = ({ phrasesByKey }) => {
             style={{ backgroundColor: '#FEF3C6', border: '1px solid #DBD0A1' }}
           >
             <InfoCircleOutlinedIcon size={16} customClass="ts-flex-shrink-0 ts-text-[#973C00]" />
-            <p className="ts-text-sm ts-font-normal" style={{ color: '#973C00' }} dangerouslySetInnerHTML={{ __html: phrasesByKey.application_trstd_login_action_required.replace('{{shopSystemName}}', capitalizedShopName) }}> 
-
+            <p className="ts-text-sm ts-font-normal" style={{ color: '#973C00' }} dangerouslySetInnerHTML={{ __html: (shopSystemName.toLowerCase() === 'shoper'
+              ? phrasesByKey.application_trstd_login_action_required_shoper
+              : phrasesByKey.application_trstd_login_action_required
+            ).replace('{{shopSystemName}}', capitalizedShopName) }}>
             </p>
           </div>
         )}


### PR DESCRIPTION
- Introduced a new phrase key for Shoper in the login translations.
- Updated the dashboard component to conditionally render the appropriate phrase based on the shop system name.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
<!--
Relates OR Closes #0000
-->

## Description
<!-- Short description about the change, what have you done? -->
