### PR TITLE
feat: add checkout confirmation widget position

### DIFF
--- a/src/locales/keys.ts
+++ b/src/locales/keys.ts
@@ -183,6 +183,7 @@ export const PHRASES_WIDGETS_KEYS: IWIDGETS_KEYS = {
   application_widgets_position_header: 'application.widgets.position.header',
   application_widgets_position_footer: 'application.widgets.position.footer',
   application_widgets_position_custom: 'application.widgets.position.custom',
+  application_widgets_position_checkout_confirmation: 'application.widgets.position.checkoutConfirmation',
   application_widgets_position_productname: 'application.widgets.position.productname',
   application_widgets_position_productdescription:
     'application.widgets.position.productdescription',

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -493,6 +493,7 @@ export type IWIDGETS_KEYS = {
   application_widgets_position_productlistings: string
   application_widgets_position_productname: string
   application_widgets_position_custom: string
+  application_widgets_position_checkout_confirmation: string
   application_widgets_name_MiniStars: string
   application_widgets_name_FullReviewList: string
   application_widgets_name_ReviewCarousel: string

--- a/src/store/widgets/widgtLocationConfig.ts
+++ b/src/store/widgets/widgtLocationConfig.ts
@@ -57,6 +57,12 @@ export const WIDGET_LOCATIONS: IWidgetLocation[] = [
     availableForType: [TypeReview.service, TypeReview.product],
   },
   {
+    id: 'wd-loc-ccp',
+    name: 'Checkout confirmation',
+    key: 'application_widgets_position_checkout_confirmation',
+    availableForType: [TypeReview.checkout],
+  },
+  {
     id: 'wdg-loc-cst',
     name: 'Custom',
     key: 'application_widgets_position_custom',


### PR DESCRIPTION
- Introduced a new widget position key for checkout confirmation in the localization files.
- Updated the widget location configuration to include the new checkout confirmation position.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
<!--
Relates OR Closes #0000
-->

## Description
<!-- Short description about the change, what have you done? -->
