### PR TITLE
TPSCON-4276 adds location for ministars

### DIFF
--- a/src/locales/keys.ts
+++ b/src/locales/keys.ts
@@ -187,6 +187,8 @@ export const PHRASES_WIDGETS_KEYS: IWIDGETS_KEYS = {
   application_widgets_position_productname: 'application.widgets.position.productname',
   application_widgets_position_productdescription:
     'application.widgets.position.productdescription',
+  application_widgets_position_ministarseverywhere:
+    'application.widgets.position.ministarsEverywhere',
   application_widgets_name_MiniStars: 'application.widgets.name.MiniStars',
   application_widgets_name_FullReviewList: 'application.widgets.name.FullReviewList',
   application_widgets_name_ReviewCarousel: 'application.widgets.name.ReviewCarousel',

--- a/src/locales/keys.ts
+++ b/src/locales/keys.ts
@@ -187,8 +187,8 @@ export const PHRASES_WIDGETS_KEYS: IWIDGETS_KEYS = {
   application_widgets_position_productname: 'application.widgets.position.productname',
   application_widgets_position_productdescription:
     'application.widgets.position.productdescription',
-  application_widgets_position_ministarseverywhere:
-    'application.widgets.position.ministarsEverywhere',
+  application_widgets_position_product_card:
+    'application.widgets.position.productCard',
   application_widgets_name_MiniStars: 'application.widgets.name.MiniStars',
   application_widgets_name_FullReviewList: 'application.widgets.name.FullReviewList',
   application_widgets_name_ReviewCarousel: 'application.widgets.name.ReviewCarousel',

--- a/src/locales/resources/de-DE.json
+++ b/src/locales/resources/de-DE.json
@@ -402,7 +402,8 @@
         "productdescription": "Produktseite (Beschreibung)",
         "productlistings": "Produktlisten",
         "productname": "Produktseite (Titel)",
-        "productpage": "Produktseite (Trusted Shops Bewertungen)"
+        "productpage": "Produktseite (Trusted Shops Bewertungen)",
+        "ministarsEverywhere": "Überall im Shop"
       },
       "productID": "Produkt ID",
       "reload": "Liste aktualisieren",

--- a/src/locales/resources/de-DE.json
+++ b/src/locales/resources/de-DE.json
@@ -403,7 +403,7 @@
         "productlistings": "Produktlisten",
         "productname": "Produktseite (Titel)",
         "productpage": "Produktseite (Trusted Shops Bewertungen)",
-        "ministarsEverywhere": "Überall im Shop"
+        "productCard": "Produktkarte"
       },
       "productID": "Produkt ID",
       "reload": "Liste aktualisieren",

--- a/src/locales/resources/en-GB.json
+++ b/src/locales/resources/en-GB.json
@@ -411,7 +411,7 @@
         "productlistings": "Product listings",
         "productname": "Product page (Title)",
         "productpage": "Product page (Trusted Shops reviews) ",
-        "ministarsEverywhere": "Everywhere in the store"
+        "productCard": "Product card"
       },
       "productID": "Product id",
       "reload": "Reload list",

--- a/src/locales/resources/en-GB.json
+++ b/src/locales/resources/en-GB.json
@@ -410,7 +410,8 @@
         "productdescription": "Product page (description)",
         "productlistings": "Product listings",
         "productname": "Product page (Title)",
-        "productpage": "Product page (Trusted Shops reviews) "
+        "productpage": "Product page (Trusted Shops reviews) ",
+        "ministarsEverywhere": "Everywhere in the store"
       },
       "productID": "Product id",
       "reload": "Reload list",

--- a/src/locales/resources/es-ES.json
+++ b/src/locales/resources/es-ES.json
@@ -401,7 +401,7 @@
         "productlistings": "Lista de productos",
         "productname": "Ficha de producto (título)",
         "productpage": "Ficha de producto (Valoraciones de Trusted Shops)",
-        "ministarsEverywhere": "En toda la tienda"
+        "productCard": "Tarjeta de producto"
       },
       "productID": "ID de producto",
       "reload": "Actualizar lista",

--- a/src/locales/resources/es-ES.json
+++ b/src/locales/resources/es-ES.json
@@ -400,7 +400,8 @@
         "productdescription": "Ficha de producto (descripción)",
         "productlistings": "Lista de productos",
         "productname": "Ficha de producto (título)",
-        "productpage": "Ficha de producto (Valoraciones de Trusted Shops)"
+        "productpage": "Ficha de producto (Valoraciones de Trusted Shops)",
+        "ministarsEverywhere": "En toda la tienda"
       },
       "productID": "ID de producto",
       "reload": "Actualizar lista",

--- a/src/locales/resources/fr-FR.json
+++ b/src/locales/resources/fr-FR.json
@@ -401,7 +401,7 @@
         "productlistings": "Listes produits",
         "productname": "Page produit (titre)",
         "productpage": "Page produit (Avis Trusted Shops)",
-        "ministarsEverywhere": "Partout dans la boutique"
+        "productCard": "Carte produit"
       },
       "productID": "Identifiant produit",
       "reload": "Recharger la liste",

--- a/src/locales/resources/fr-FR.json
+++ b/src/locales/resources/fr-FR.json
@@ -400,7 +400,8 @@
         "productdescription": "Page produit (Description)",
         "productlistings": "Listes produits",
         "productname": "Page produit (titre)",
-        "productpage": "Page produit (Avis Trusted Shops)"
+        "productpage": "Page produit (Avis Trusted Shops)",
+        "ministarsEverywhere": "Partout dans la boutique"
       },
       "productID": "Identifiant produit",
       "reload": "Recharger la liste",

--- a/src/locales/resources/it-IT.json
+++ b/src/locales/resources/it-IT.json
@@ -401,7 +401,7 @@
         "productlistings": "Lista dei prodotti",
         "productname": "Pagina prodotto (titolo)",
         "productpage": "Pagina prodotto (recensioni Trusted Shops)",
-        "ministarsEverywhere": "Ovunque nel negozio"
+        "productCard": "Scheda prodotto"
       },
       "productID": "ID prodotto",
       "reload": "Ricarica la lista",

--- a/src/locales/resources/it-IT.json
+++ b/src/locales/resources/it-IT.json
@@ -400,7 +400,8 @@
         "productdescription": "Pagina prodotto (descrizione)",
         "productlistings": "Lista dei prodotti",
         "productname": "Pagina prodotto (titolo)",
-        "productpage": "Pagina prodotto (recensioni Trusted Shops)"
+        "productpage": "Pagina prodotto (recensioni Trusted Shops)",
+        "ministarsEverywhere": "Ovunque nel negozio"
       },
       "productID": "ID prodotto",
       "reload": "Ricarica la lista",

--- a/src/locales/resources/nl-NL.json
+++ b/src/locales/resources/nl-NL.json
@@ -401,7 +401,7 @@
         "productlistings": "Product lijsten",
         "productname": "Productpagina (titel)",
         "productpage": "Ficha de producto (Valoraciones de Trusted Shops)",
-        "ministarsEverywhere": "Overal in de winkel"
+        "productCard": "Productkaart"
       },
       "productID": "Product ID",
       "reload": "Lijst opnieuw laden",

--- a/src/locales/resources/nl-NL.json
+++ b/src/locales/resources/nl-NL.json
@@ -400,7 +400,8 @@
         "productdescription": "Productpagina (beschrijving)",
         "productlistings": "Product lijsten",
         "productname": "Productpagina (titel)",
-        "productpage": "Ficha de producto (Valoraciones de Trusted Shops)"
+        "productpage": "Ficha de producto (Valoraciones de Trusted Shops)",
+        "ministarsEverywhere": "Overal in de winkel"
       },
       "productID": "Product ID",
       "reload": "Lijst opnieuw laden",

--- a/src/locales/resources/pl-PL.json
+++ b/src/locales/resources/pl-PL.json
@@ -401,7 +401,7 @@
         "productlistings": "Listy produktów",
         "productname": "Strona produktu (tytuł)",
         "productpage": "Strona produktu (opinie Trusted Shops)",
-        "ministarsEverywhere": "W całym sklepie"
+        "productCard": "Karta produktu"
       },
       "productID": "ID produktu",
       "reload": "Wczytaj listę ponownie",

--- a/src/locales/resources/pl-PL.json
+++ b/src/locales/resources/pl-PL.json
@@ -400,7 +400,8 @@
         "productdescription": "Strona produktu (opis)",
         "productlistings": "Listy produktów",
         "productname": "Strona produktu (tytuł)",
-        "productpage": "Strona produktu (opinie Trusted Shops)"
+        "productpage": "Strona produktu (opinie Trusted Shops)",
+        "ministarsEverywhere": "W całym sklepie"
       },
       "productID": "ID produktu",
       "reload": "Wczytaj listę ponownie",

--- a/src/locales/resources/pt-PT.json
+++ b/src/locales/resources/pt-PT.json
@@ -399,7 +399,8 @@
         "productdescription": "Ficha de produto (descrição)",
         "productlistings": "Listagens de produtos",
         "productname": "Ficha de produto (título)",
-        "productpage": "Ficha de produto (avaliações de Trusted Shops)"
+        "productpage": "Ficha de produto (avaliações de Trusted Shops)",
+        "ministarsEverywhere": "Em toda a loja"
       },
       "productID": "ID do produto",
       "reload": "Recarregar a lista",

--- a/src/locales/resources/pt-PT.json
+++ b/src/locales/resources/pt-PT.json
@@ -400,7 +400,7 @@
         "productlistings": "Listagens de produtos",
         "productname": "Ficha de produto (título)",
         "productpage": "Ficha de produto (avaliações de Trusted Shops)",
-        "ministarsEverywhere": "Em toda a loja"
+        "productCard": "Cartão de produto"
       },
       "productID": "ID do produto",
       "reload": "Recarregar a lista",

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -494,7 +494,7 @@ export type IWIDGETS_KEYS = {
   application_widgets_position_productname: string
   application_widgets_position_custom: string
   application_widgets_position_checkout_confirmation: string
-  application_widgets_position_ministarseverywhere: string
+  application_widgets_position_product_card: string
   application_widgets_name_MiniStars: string
   application_widgets_name_FullReviewList: string
   application_widgets_name_ReviewCarousel: string

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -494,6 +494,7 @@ export type IWIDGETS_KEYS = {
   application_widgets_position_productname: string
   application_widgets_position_custom: string
   application_widgets_position_checkout_confirmation: string
+  application_widgets_position_ministarseverywhere: string
   application_widgets_name_MiniStars: string
   application_widgets_name_FullReviewList: string
   application_widgets_name_ReviewCarousel: string

--- a/src/store/widgets/widgtLocationConfig.ts
+++ b/src/store/widgets/widgtLocationConfig.ts
@@ -69,9 +69,9 @@ export const WIDGET_LOCATIONS: IWidgetLocation[] = [
     availableForType: [TypeReview.service, TypeReview.product, TypeReview.checkout],
   },
   {
-    id: 'wdg-loc-mini',
-    name: 'Everywhere in the store',
-    key: 'application_widgets_position_ministarseverywhere',
+    id: 'wdg-loc-product-card',
+    name: 'Product card',
+    key: 'application_widgets_position_product_card',
     availableForType: [TypeReview.service],
   },
 ]

--- a/src/store/widgets/widgtLocationConfig.ts
+++ b/src/store/widgets/widgtLocationConfig.ts
@@ -68,4 +68,10 @@ export const WIDGET_LOCATIONS: IWidgetLocation[] = [
     key: 'application_widgets_position_custom',
     availableForType: [TypeReview.service, TypeReview.product, TypeReview.checkout],
   },
+  {
+    id: 'wdg-loc-mini',
+    name: 'Everywhere in the store',
+    key: 'application_widgets_position_ministarseverywhere',
+    availableForType: [TypeReview.service],
+  },
 ]

--- a/src/store/widgets/widgtLocationConfig.ts
+++ b/src/store/widgets/widgtLocationConfig.ts
@@ -72,6 +72,6 @@ export const WIDGET_LOCATIONS: IWidgetLocation[] = [
     id: 'wdg-loc-product-card',
     name: 'Product card',
     key: 'application_widgets_position_product_card',
-    availableForType: [TypeReview.service],
+    availableForType: [TypeReview.product],
   },
 ]


### PR DESCRIPTION
This pull request adds support for a new widget location called "Everywhere in the store" (internally referenced as `ministarsEverywhere`) to the application. The update includes localization keys and translations for this new location across all supported languages, type definitions, and widget location configuration.

**Localization and Widget Configuration Updates:**

* Added the `application_widgets_position_ministarseverywhere` key and corresponding type definition in `IWIDGETS_KEYS` to support the new widget location. [[1]](diffhunk://#diff-b2757da0d02c51bfb6828552426983a9dbbdc55e398a10bfdb797d0f3a3cf280R190-R191) [[2]](diffhunk://#diff-d5af6f10dfe12a8af0c5cfbf9fec425f4321984aedd0c1f8b1361956d942d7e4R497)
* Updated all language resource files (`en-GB.json`, `de-DE.json`, `es-ES.json`, `fr-FR.json`, `it-IT.json`, `nl-NL.json`, `pl-PL.json`, `pt-PT.json`) to include the translation for "Everywhere in the store" under the new `ministarsEverywhere` key. [[1]](diffhunk://#diff-478d85c29fb1aea0d7afc3ed003f456ae3875970a91d1217b9939f0f09f2d6c9L413-R414) [[2]](diffhunk://#diff-ce7f7c2547f11fc49319d8fb45f35f8b4fa646c94004864164ee858dd674d4feL405-R406) [[3]](diffhunk://#diff-e6ed2f78d9bf5cc085d34329fdfe6c5c8ef67c9bd9eae8412eb9d2c5f09a02cbL403-R404) [[4]](diffhunk://#diff-726be11fadfcb3d330215d3555ceaaf1a2da732d46100291faf1d4d7f50aaab8L403-R404) [[5]](diffhunk://#diff-02326d1c956af86fa8190ce5424def5bfcaa477a1b900ebd250d239ab6b54672L403-R404) [[6]](diffhunk://#diff-d6709ebdac725b795bc76cac0bb7aac86dfff130a5977a666f6227f5e6179a6bL403-R404) [[7]](diffhunk://#diff-ba74dbea79f336d7f32a87771972a497c3724f3dd1570fbbc21d661cde940111L403-R404) [[8]](diffhunk://#diff-509933a85e74b4c8c9dffa7a091b7d95f1585c48aa3576a4affc27cc43441316L402-R403)
* Added a new entry to the `WIDGET_LOCATIONS` array in `widgtLocationConfig.ts` to register the "Everywhere in the store" location for service-type widgets.

Signed-off-by: Arens Myzyri <arens.myzyri@trustedshops.com>