### PR TITLE
feat: Add structured data markup (JSON-LD) toggle to Trustbadge tab

### DIFF
--- a/src/baseLayers/baseLayerDev.ts
+++ b/src/baseLayers/baseLayerDev.ts
@@ -20,18 +20,6 @@ import { getUsedOrderStaruses } from './testData/getUsedOrderStatuses'
 export const DEV = 'development'
 export const TEST = 'test'
 
-// Simulate the upcoming events-lib entries for structured data markup so the
-// mock baselayer can register/handle them before they exist in eventsLib.js
-if (Boolean(Number(process.env.VITE_USE_MOCK_BASELAYER))) {
-  EVENTS.GET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED =
-    EVENTS.GET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED ||
-    'TS_GET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED'
-  EVENTS.SET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED =
-    EVENTS.SET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED ||
-    'TS_SET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED'
-  EVENTS.SAVE_STRUCTURED_MARKUP_CONFIGURATION =
-    EVENTS.SAVE_STRUCTURED_MARKUP_CONFIGURATION || 'TS_SAVE_STRUCTURED_MARKUP_CONFIGURATION'
-}
 
 const credentials = {
   clientId: import.meta.env.VITE_CLIENT_ID || '',
@@ -267,6 +255,7 @@ export const baseLayerDev = (): void => {
             )
           }, 400)
         } catch (error) {
+          console.error('SAVE_STRUCTURED_MARKUP_CONFIGURATION_BaseLayer failed', error)
           setTimeout(() => {
             sendingNotification(
               EVENTS.SAVE_STRUCTURED_MARKUP_CONFIGURATION,

--- a/src/baseLayers/baseLayerDev.ts
+++ b/src/baseLayers/baseLayerDev.ts
@@ -13,11 +13,25 @@ import { getWidgetLocation } from './testData/getWidgetLocation'
 import { getWidgets } from './testData/getWidgets'
 import { getTrstdLoginConfiguration } from './testData/getTrstdLoginMock'
 import { getTrstdLoginLocation } from './testData/getTrstdLoginLocation'
+import { getStructuredMarkupConfiguration } from './testData/getStructuredMarkupMock'
 import { IMappedChannel, ITrstdLogin, IWidgets } from './types'
 import { getUsedOrderStaruses } from './testData/getUsedOrderStatuses'
 
 export const DEV = 'development'
 export const TEST = 'test'
+
+// Simulate the upcoming events-lib entries for structured data markup so the
+// mock baselayer can register/handle them before they exist in eventsLib.js
+if (Boolean(Number(process.env.VITE_USE_MOCK_BASELAYER))) {
+  EVENTS.GET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED =
+    EVENTS.GET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED ||
+    'TS_GET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED'
+  EVENTS.SET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED =
+    EVENTS.SET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED ||
+    'TS_SET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED'
+  EVENTS.SAVE_STRUCTURED_MARKUP_CONFIGURATION =
+    EVENTS.SAVE_STRUCTURED_MARKUP_CONFIGURATION || 'TS_SAVE_STRUCTURED_MARKUP_CONFIGURATION'
+}
 
 const credentials = {
   clientId: import.meta.env.VITE_CLIENT_ID || '',
@@ -215,6 +229,53 @@ export const baseLayerDev = (): void => {
             payload: getTrstdLoginLocation(DEFAULT_ENV),
           })
         }, 400)
+      },
+
+      [EVENTS.GET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED]: () => {
+        console.log('GET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED')
+        const saved = sessionStorage.getItem('structuredMarkup')
+        setTimeout(() => {
+          dispatchAction({
+            action: EVENTS.SET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED,
+            payload: saved ? JSON.parse(saved) : getStructuredMarkupConfiguration(DEFAULT_ENV),
+          })
+        }, 400)
+      },
+
+      [EVENTS.SAVE_STRUCTURED_MARKUP_CONFIGURATION]: (event: {
+        payload: {
+          eTrustedChannelRef: string
+          salesChannelRef: string
+          tsId: string
+          enabled: boolean
+        }
+      }) => {
+        try {
+          console.log('SAVE_STRUCTURED_MARKUP_CONFIGURATION_BaseLayer', event.payload)
+          const config = { structuredMarkupEnabled: event.payload.enabled }
+          sessionStorage.setItem('structuredMarkup', JSON.stringify(config))
+          setTimeout(() => {
+            dispatchAction({
+              action: EVENTS.SET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED,
+              payload: config,
+            })
+            sendingNotification(
+              EVENTS.SAVE_STRUCTURED_MARKUP_CONFIGURATION,
+              'STRUCTURED MARKUP CONFIGURATION SAVED',
+              'success',
+              'save'
+            )
+          }, 400)
+        } catch (error) {
+          setTimeout(() => {
+            sendingNotification(
+              EVENTS.SAVE_STRUCTURED_MARKUP_CONFIGURATION,
+              'STRUCTURED MARKUP CONFIGURATION NOT SAVED',
+              'error',
+              'save'
+            )
+          }, 400)
+        }
       },
 
 

--- a/src/baseLayers/testData/getInformationOfSystem.ts
+++ b/src/baseLayers/testData/getInformationOfSystem.ts
@@ -16,6 +16,7 @@ export const getInformationOfSystem = (
         allowsEditIntegrationCode: true,
         allowsSupportWidgets: true,
         useVersionNumberOfConnector: '2.0',
+        allowsSupportStructuredMarkup: true,
       }
     case TEST: //value for 'test'
       return {
@@ -27,6 +28,7 @@ export const getInformationOfSystem = (
         allowsSendReviewInvitesForPreviousOrders: true,
         useVersionNumberOfConnector: '2.0',
         allowsSupportTrstdLogin: true,
+        allowsSupportStructuredMarkup: true,
       }
     case 'no_value':
       return {}

--- a/src/baseLayers/testData/getStructuredMarkupMock.ts
+++ b/src/baseLayers/testData/getStructuredMarkupMock.ts
@@ -1,0 +1,20 @@
+import { DEV, TEST } from '../baseLayerDev'
+
+export const getStructuredMarkupConfiguration = (
+  defaultEnv?: string
+): { structuredMarkupEnabled: boolean } => {
+  switch (process.env.infoSystem || defaultEnv) {
+    case DEV: // value for 'development'
+      return {
+        structuredMarkupEnabled: false,
+      }
+    case TEST: //value for 'test'
+      return {
+        structuredMarkupEnabled: true,
+      }
+    default:
+      return {
+        structuredMarkupEnabled: false,
+      }
+  }
+}

--- a/src/baseLayers/testData/getStructuredMarkupMock.ts
+++ b/src/baseLayers/testData/getStructuredMarkupMock.ts
@@ -1,18 +1,14 @@
-import { DEV, TEST } from '../baseLayerDev'
+import { TEST } from '../baseLayerDev'
 
 export const getStructuredMarkupConfiguration = (
   defaultEnv?: string
 ): { structuredMarkupEnabled: boolean } => {
   switch (process.env.infoSystem || defaultEnv) {
-    case DEV: // value for 'development'
-      return {
-        structuredMarkupEnabled: false,
-      }
     case TEST: //value for 'test'
       return {
         structuredMarkupEnabled: true,
       }
-    default:
+    default: // 'development' and everything else defaults to disabled
       return {
         structuredMarkupEnabled: false,
       }

--- a/src/baseLayers/testData/getStructuredMarkupMock.ts
+++ b/src/baseLayers/testData/getStructuredMarkupMock.ts
@@ -3,14 +3,10 @@ import { TEST } from '../baseLayerDev'
 export const getStructuredMarkupConfiguration = (
   defaultEnv?: string
 ): { structuredMarkupEnabled: boolean } => {
-  switch (process.env.infoSystem || defaultEnv) {
-    case TEST: //value for 'test'
-      return {
-        structuredMarkupEnabled: true,
-      }
-    default: // 'development' and everything else defaults to disabled
-      return {
-        structuredMarkupEnabled: false,
-      }
+  const env = process.env.infoSystem || defaultEnv
+
+  // enabled in 'test', disabled in 'development' and everything else
+  return {
+    structuredMarkupEnabled: env === TEST,
   }
 }

--- a/src/eventsContainer/index.tsx
+++ b/src/eventsContainer/index.tsx
@@ -37,6 +37,7 @@ const EventsContainer: FC<{ children: VNode }> = ({ children }) => {
     getTrstdLoginData,
     setTrstdLoginLocations,
     setTrstdLoginLoadingBL,
+    setStructuredMarkupEnabled,
   } = useStore()
 
   useEffect(() => {
@@ -80,6 +81,12 @@ const EventsContainer: FC<{ children: VNode }> = ({ children }) => {
 
       [EVENTS.SET_LOCATION_FOR_TRSTDLOGIN]: (event: { payload: ITrstdLoginLocation[] }) =>
         setTrstdLoginLocations(event.payload),
+
+      // STRUCTURED MARKUP
+
+      [EVENTS.SET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED]: (event: {
+        payload: Nullable<{ structuredMarkupEnabled?: boolean }>
+      }) => setStructuredMarkupEnabled(event.payload?.structuredMarkupEnabled ?? false),
 
 
       [EVENTS.SET_PRODUCT_REVIEW_FOR_CHANNEL]: (event: { payload: Nullable<IMappedChannel> }) =>

--- a/src/locales/keys.ts
+++ b/src/locales/keys.ts
@@ -152,7 +152,10 @@ const PHRASES_TRUSTBADGE_KEYS: ITRUSTBADGE_KEYS = {
   application_trustbadge_about_title: 'application.trustbadge.about.title',
   application_trustbadge_about_description: 'application.trustbadge.about.description',
   application_trustbadge_about_learnMore: 'application.trustbadge.about.learnMore',
-  application_trustbadge_about_learnMore_url: 'application.trustbadge.about.learnMore_url'
+  application_trustbadge_about_learnMore_url: 'application.trustbadge.about.learnMore_url',
+  application_trustbadge_structuredMarkup_title: 'application.trustbadge.structuredMarkup.title',
+  application_trustbadge_structuredMarkup_description: 'application.trustbadge.structuredMarkup.description',
+  application_trustbadge_structuredMarkup_toggle_label: 'application.trustbadge.structuredMarkup.toggle.label',
 }
 
 export const PHRASES_WIDGETS_KEYS: IWIDGETS_KEYS = {

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -459,8 +459,11 @@ export type ITRUSTBADGE_KEYS = {
   application_trustbadge_placementSection_right: string
   application_trustbadge_about_title: string
   application_trustbadge_about_description: string
-  application_trustbadge_about_learnMore: string  
+  application_trustbadge_about_learnMore: string
   application_trustbadge_about_learnMore_url: string
+  application_trustbadge_structuredMarkup_title: string
+  application_trustbadge_structuredMarkup_description: string
+  application_trustbadge_structuredMarkup_toggle_label: string
 }
 
 export type IWIDGETS_KEYS = {

--- a/src/modules/dashboard/index.tsx
+++ b/src/modules/dashboard/index.tsx
@@ -155,7 +155,7 @@ const DashboardPageModule: FC<{
       }
 
       if (
-        Object.prototype.hasOwnProperty.call(infoOfSystem, 'allowsSupportStructuredMarkup') &&
+        Object.hasOwn(infoOfSystem, 'allowsSupportStructuredMarkup') &&
         infoOfSystem.allowsSupportStructuredMarkup
       ) {
         getStructuredMarkupConfiguration(selectedShopChannels)

--- a/src/modules/dashboard/index.tsx
+++ b/src/modules/dashboard/index.tsx
@@ -123,6 +123,8 @@ const DashboardPageModule: FC<{
     setInitialOrderStatusByMapping,
     getTrstdLoginConfiguration,
     clearTrstdLoginState,
+    getStructuredMarkupConfiguration,
+    clearStructuredMarkupState,
   } = useStore()
 
   const { toastList } = useStore(selectorNotificationStore)
@@ -143,12 +145,20 @@ const DashboardPageModule: FC<{
       getTrustbadge(selectedShopChannels)
       clearWidgetData()
       clearTrstdLoginState()
+      clearStructuredMarkupState()
 
       if (
         Object.prototype.hasOwnProperty.call(infoOfSystem, 'allowsSupportTrstdLogin') &&
         infoOfSystem.allowsSupportTrstdLogin
       ) {
         getTrstdLoginConfiguration(selectedShopChannels)
+      }
+
+      if (
+        Object.prototype.hasOwnProperty.call(infoOfSystem, 'allowsSupportStructuredMarkup') &&
+        infoOfSystem.allowsSupportStructuredMarkup
+      ) {
+        getStructuredMarkupConfiguration(selectedShopChannels)
       }
 
       setIsLoading(true)

--- a/src/modules/dashboard/tabTrustBadge/index.tsx
+++ b/src/modules/dashboard/tabTrustBadge/index.tsx
@@ -17,8 +17,10 @@ import {
   selectorAuth,
   selectorChannels,
   selectorInfoOfSystem,
+  selectorStructuredMarkup,
   selectorTrustbadgeState,
 } from '@/store/selector'
+import StructuredMarkupSection from './structuredMarkupSection'
 import { ITrustbadgeChildren } from '@/baseLayers/types'
 import useStore from '@/store/useStore'
 import EditIntegrationCodeProps from './editIntegrationCode'
@@ -48,7 +50,12 @@ const TrustBadgeTab: FC<TabProps> = ({ phrasesByKey }) => {
     useState<Nullable<ITrustbadgeChildren>>(null)
   const [previewTab, setPreviewTab] = useState<'desktop' | 'mobile'>('mobile')
 
-  const { updateTrustbadgeDataFromTextaria, updateTrustbadgeData, setIsLoadingBL } = useStore()
+  const {
+    updateTrustbadgeDataFromTextaria,
+    updateTrustbadgeData,
+    setIsLoadingBL,
+    updateStructuredMarkupEnabled,
+  } = useStore()
   const {
     trustbadgeId,
     trustbadgeDataChild,
@@ -59,6 +66,9 @@ const TrustBadgeTab: FC<TabProps> = ({ phrasesByKey }) => {
   const { user } = useStore(selectorAuth)
   const { infoOfSystem } = useStore(selectorInfoOfSystem)
   const { isLoadingSave, selectedShopChannels } = useStore(selectorChannels)
+  const { isLoadingStructuredMarkup, structuredMarkupEnabled } = useStore(
+    selectorStructuredMarkup,
+  )
   const isActive = !isDisabled
 
   useEffect(() => {
@@ -138,6 +148,9 @@ const TrustBadgeTab: FC<TabProps> = ({ phrasesByKey }) => {
 
   const diactivateTB = (data: Nullable<ITrustbadgeChildren>): void => {
     setIsLoadingBL(true)
+    if (infoOfSystem.allowsSupportStructuredMarkup && structuredMarkupEnabled) {
+      updateStructuredMarkupEnabled(false)
+    }
     const disabledChild = data || {
       tag: trustbadgeDataChild.tag,
       attributes: {
@@ -206,7 +219,9 @@ const TrustBadgeTab: FC<TabProps> = ({ phrasesByKey }) => {
   return (
     phrasesByKey && (
       <div className="ts-flex ts-flex-col ts-gap-6">
-        {(isLoadingAPI || isLoadingBL || isLoadingSave) && <ScrinSpinner />}
+        {(isLoadingAPI || isLoadingBL || isLoadingSave || isLoadingStructuredMarkup) && (
+          <ScrinSpinner />
+        )}
 
         {/* Trustbadge header - no card */}
         <div className="ts-pb-1">
@@ -430,6 +445,14 @@ const TrustBadgeTab: FC<TabProps> = ({ phrasesByKey }) => {
             </StyledButton>
           </div>
         </div>
+
+        {/* Structured data markup */}
+        {infoOfSystem.allowsSupportStructuredMarkup && (
+          <StructuredMarkupSection
+            phrasesByKey={phrasesByKey}
+            isTrustbadgeDisabled={isDisabled}
+          />
+        )}
 
         {/* About the Trustbadge */}
         <div

--- a/src/modules/dashboard/tabTrustBadge/structuredMarkupSection.tsx
+++ b/src/modules/dashboard/tabTrustBadge/structuredMarkupSection.tsx
@@ -1,0 +1,80 @@
+import { h } from 'preact'
+import { FC } from 'preact/compat'
+import { selectorStructuredMarkup } from '@/store/selector'
+import { DASHBOARD_KEYS } from '@/locales/types'
+import useStore from '@/store/useStore'
+
+interface Props {
+  phrasesByKey: DASHBOARD_KEYS
+  isTrustbadgeDisabled: boolean
+}
+
+const StructuredMarkupSection: FC<Props> = ({ phrasesByKey, isTrustbadgeDisabled }) => {
+  const { updateStructuredMarkupEnabled } = useStore()
+  const { structuredMarkupEnabled, isLoadingStructuredMarkup } = useStore(
+    selectorStructuredMarkup,
+  )
+
+  const isSwitchBlocked =
+    isLoadingStructuredMarkup || (isTrustbadgeDisabled && !structuredMarkupEnabled)
+
+  const handleSwitch = () => {
+    if (isSwitchBlocked) return
+    updateStructuredMarkupEnabled(!structuredMarkupEnabled)
+  }
+
+  return (
+    <div className="ts-bg-white ts-rounded-[14px] ts-shadow-md ts-p-6">
+      <h2 className="ts-text-default ts-font-bold ts-mb-1" style={{ fontSize: '16px' }}>
+        {phrasesByKey.application_trustbadge_structuredMarkup_title ||
+          'Structured data markup'}
+      </h2>
+      <p className="ts-text-sm ts-font-normal ts-mb-6" style={{ color: '#6b7280' }}>
+        {phrasesByKey.application_trustbadge_structuredMarkup_description ||
+          'Adds structured data markup (JSON-LD) with your Trusted Shops ratings to your shop pages. It is inserted into the head of your shop website and helps search engines display your star rating in search results.'}
+      </p>
+
+      <div style={{ borderBottom: '1px solid #E5E7EB', margin: '20px 0' }} />
+
+      <div className="ts-flex ts-items-center ts-justify-between">
+        <span className="ts-text-sm ts-font-normal ts-text-default">
+          {phrasesByKey.application_trustbadge_structuredMarkup_toggle_label ||
+            'Enable structured data markup'}
+        </span>
+        <button
+          id="switch_button_structuredMarkup"
+          type="button"
+          onClick={handleSwitch}
+          className="ts-border-0 ts-p-0 ts-cursor-pointer ts-flex-shrink-0"
+          style={{
+            width: '44px',
+            height: '24px',
+            borderRadius: '12px',
+            backgroundColor: structuredMarkupEnabled ? '#16A34A' : '#D1D5DB',
+            position: 'relative',
+            transition: 'background-color 0.2s ease',
+            opacity: isSwitchBlocked ? 0.25 : 1,
+            cursor: isSwitchBlocked ? 'not-allowed' : 'pointer',
+          }}
+        >
+          <div
+            style={{
+              width: '20px',
+              height: '20px',
+              borderRadius: '50%',
+              backgroundColor: '#FFFFFF',
+              position: 'absolute',
+              top: '2px',
+              left: structuredMarkupEnabled ? '22px' : '2px',
+              transition: 'left 0.2s ease',
+              boxShadow: '0 1px 3px rgba(0,0,0,0.15)',
+            }}
+          />
+        </button>
+      </div>
+
+    </div>
+  )
+}
+
+export default StructuredMarkupSection

--- a/src/store/info/types.ts
+++ b/src/store/info/types.ts
@@ -11,6 +11,7 @@ export interface IUserInfo {
   useVersionNumberOfConnector?: string
   allowsTrustedCheckoutWidget?: boolean
   allowsSupportTrstdLogin?: boolean
+  allowsSupportStructuredMarkup?: boolean
 }
 
 export interface InfoState {

--- a/src/store/selector.ts
+++ b/src/store/selector.ts
@@ -5,6 +5,7 @@ import { ITrustbadgeState } from './trustbadge/types'
 import { INotificationState } from './notification/types'
 import { IReviewInvitesState } from './reviewInvites/types'
 import { ITrstdLoginState } from './trstdLogin/types'
+import { IStructuredMarkupState } from './structuredMarkup/types'
 import { AppStore } from '@/store/useStore'
 
 export const selectState = <T>(store: { state: T }): T => store.state
@@ -29,6 +30,10 @@ export const selectorNotificationStore = (store: {
 export const selectorTrstdLogin = (store: {
   trstdLoginState: ITrstdLoginState
 }): ITrstdLoginState => store.trstdLoginState
+
+export const selectorStructuredMarkup = (store: {
+  structuredMarkupState: IStructuredMarkupState
+}): IStructuredMarkupState => store.structuredMarkupState
 
 export const selectAllState = (store: AppStore) => {
   /* eslint-disable*/

--- a/src/store/structuredMarkup/index.ts
+++ b/src/store/structuredMarkup/index.ts
@@ -1,0 +1,87 @@
+import { GetState, SetState } from 'zustand'
+import { dispatchAction, EVENTS } from '@/eventsLib'
+import { AppStore } from '../useStore'
+import { IStructuredMarkupState, IStructuredMarkupStore } from './types'
+import { IMappedChannel } from '../channel/types'
+
+const initialState: IStructuredMarkupState = {
+  structuredMarkupEnabled: false,
+  isLoadingStructuredMarkup: false,
+}
+
+export const structuredMarkupStore = (
+  set: SetState<AppStore>,
+  get: GetState<AppStore>,
+): IStructuredMarkupStore => ({
+  structuredMarkupState: initialState,
+
+  setStructuredMarkupEnabled: (value: boolean) => {
+    set(store => ({
+      structuredMarkupState: {
+        ...store.structuredMarkupState,
+        structuredMarkupEnabled: value,
+        isLoadingStructuredMarkup: false,
+      },
+    }))
+  },
+
+  setStructuredMarkupLoading: (value: boolean) => {
+    set(store => ({
+      structuredMarkupState: {
+        ...store.structuredMarkupState,
+        isLoadingStructuredMarkup: value,
+      },
+    }))
+  },
+
+  getStructuredMarkupConfiguration: (channel: IMappedChannel) => {
+    set(store => ({
+      structuredMarkupState: {
+        ...store.structuredMarkupState,
+        structuredMarkupEnabled: false,
+      },
+    }))
+
+    if (EVENTS.GET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED) {
+      dispatchAction({
+        action: EVENTS.GET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED,
+        payload: {
+          id: channel.eTrustedChannelRef,
+          salesChannelRef: channel.salesChannelRef,
+          eTrustedChannelRef: channel.eTrustedChannelRef,
+        },
+      })
+    }
+  },
+
+  updateStructuredMarkupEnabled: (enabled: boolean) => {
+    const state = get()
+    const { selectedShopChannels } = state.channelState
+    const { trustbadgeId } = state.trustbadgeState
+
+    if (EVENTS.SAVE_STRUCTURED_MARKUP_CONFIGURATION) {
+      dispatchAction({
+        action: EVENTS.SAVE_STRUCTURED_MARKUP_CONFIGURATION,
+        payload: {
+          eTrustedChannelRef: selectedShopChannels.eTrustedChannelRef,
+          salesChannelRef: selectedShopChannels.salesChannelRef,
+          tsId: trustbadgeId,
+          enabled,
+        },
+      })
+    }
+
+    set(store => ({
+      structuredMarkupState: {
+        ...store.structuredMarkupState,
+        structuredMarkupEnabled: enabled,
+      },
+    }))
+  },
+
+  clearStructuredMarkupState: () => {
+    set(() => ({
+      structuredMarkupState: { ...initialState },
+    }))
+  },
+})

--- a/src/store/structuredMarkup/types.ts
+++ b/src/store/structuredMarkup/types.ts
@@ -1,0 +1,15 @@
+import { IMappedChannel } from '../channel/types'
+
+export interface IStructuredMarkupState {
+  structuredMarkupEnabled: boolean
+  isLoadingStructuredMarkup: boolean
+}
+
+export interface IStructuredMarkupStore {
+  structuredMarkupState: IStructuredMarkupState
+  setStructuredMarkupEnabled: (value: boolean) => void
+  setStructuredMarkupLoading: (value: boolean) => void
+  getStructuredMarkupConfiguration: (channel: IMappedChannel) => void
+  updateStructuredMarkupEnabled: (enabled: boolean) => void
+  clearStructuredMarkupState: () => void
+}

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -21,6 +21,8 @@ import { reviewInvitesActionsStore } from './reviewInvites/reviewInvitesSendActi
 import { reviewInvitesActionsStore_v2 } from './reviewInvites/reviewInvitesSendActions_v2'
 import { trstdLoginStore } from './trstdLogin'
 import { ITrstdLoginStore } from './trstdLogin/types'
+import { structuredMarkupStore } from './structuredMarkup'
+import { IStructuredMarkupStore } from './structuredMarkup/types'
 export type AppStore = ITbStore &
   InfoStore &
   IAuthStore &
@@ -30,7 +32,8 @@ export type AppStore = ITbStore &
   IReviewInvitesStore &
   ReviewInvitesActionsStore &
   ReviewInvitesActionsStore_2 &
-  ITrstdLoginStore
+  ITrstdLoginStore &
+  IStructuredMarkupStore
 
 const useStore = create<AppStore>((set, get) => ({
   ...authStore(set, get),
@@ -43,6 +46,7 @@ const useStore = create<AppStore>((set, get) => ({
   ...reviewInvitesActionsStore(set, get),
   ...reviewInvitesActionsStore_v2(set, get),
   ...trstdLoginStore(set, get),
+  ...structuredMarkupStore(set, get),
 }))
 
 export default useStore


### PR DESCRIPTION
- New section in Trustbadge tab behind allowsSupportStructuredMarkup feature flag
- Toggle dispatches SAVE_STRUCTURED_MARKUP_CONFIGURATION with channel refs, tsId and enabled state
- Configuration is loaded per channel via GET/SET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED
- Markup cannot be enabled while the Trustbadge is disabled; deactivating the Trustbadge also disables the markup
- Mock baselayer simulates the new events for local development -Static translations will be removed after design is confirmed and the translations keys are added through phrase

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
<!--
Relates OR Closes #0000
-->

## Description
<!-- Short description about the change, what have you done? -->
