### PR TITLE
feat: Include structured markup state in configuration calls

### DIFF
--- a/src/modules/dashboard/tabTrustBadge/index.tsx
+++ b/src/modules/dashboard/tabTrustBadge/index.tsx
@@ -109,6 +109,9 @@ const TrustBadgeTab: FC<TabProps> = ({ phrasesByKey }) => {
       ...(store.infoState.infoOfSystem.allowsSupportTrstdLogin && {
         trstdLoginState: store.trstdLoginState,
       }),
+      ...(store.infoState.infoOfSystem.allowsSupportStructuredMarkup && {
+        structuredMarkupState: store.structuredMarkupState,
+      }),
     }
   }
 
@@ -149,7 +152,7 @@ const TrustBadgeTab: FC<TabProps> = ({ phrasesByKey }) => {
   const diactivateTB = (data: Nullable<ITrustbadgeChildren>): void => {
     setIsLoadingBL(true)
     if (infoOfSystem.allowsSupportStructuredMarkup && structuredMarkupEnabled) {
-      updateStructuredMarkupEnabled(false)
+      updateStructuredMarkupEnabled(false, { skipConfigurationCall: true })
     }
     const disabledChild = data || {
       tag: trustbadgeDataChild.tag,

--- a/src/store/selector.ts
+++ b/src/store/selector.ts
@@ -49,5 +49,8 @@ export const selectAllState = (store: AppStore) => {
     ...(store.infoState.infoOfSystem.allowsSupportTrstdLogin && {
       trstdLoginState: store.trstdLoginState,
     }),
+    ...(store.infoState.infoOfSystem.allowsSupportStructuredMarkup && {
+      structuredMarkupState: store.structuredMarkupState,
+    }),
   }
 }

--- a/src/store/structuredMarkup/index.ts
+++ b/src/store/structuredMarkup/index.ts
@@ -1,5 +1,8 @@
 import { GetState, SetState } from 'zustand'
 import { dispatchAction, EVENTS } from '@/eventsLib'
+import { putEtrustedConfiguration } from '@/api/api'
+import { handleEtrustedConfiguration } from '@/utils/configurationDataHandler'
+import { selectAllState } from '../selector'
 import { AppStore } from '../useStore'
 import { IStructuredMarkupState, IStructuredMarkupStore } from './types'
 import { IMappedChannel } from '../channel/types'
@@ -54,10 +57,14 @@ export const structuredMarkupStore = (
     }
   },
 
-  updateStructuredMarkupEnabled: (enabled: boolean) => {
+  updateStructuredMarkupEnabled: (
+    enabled: boolean,
+    options?: { skipConfigurationCall?: boolean },
+  ) => {
     const state = get()
     const { selectedShopChannels } = state.channelState
     const { trustbadgeId } = state.trustbadgeState
+    const token = state.auth.user?.access_token
 
     if (EVENTS.SAVE_STRUCTURED_MARKUP_CONFIGURATION) {
       dispatchAction({
@@ -77,6 +84,18 @@ export const structuredMarkupStore = (
         structuredMarkupEnabled: enabled,
       },
     }))
+
+    // skipped when the caller sends its own configuration call afterwards,
+    // e.g. trustbadge deactivation which already includes the updated
+    // structuredMarkupState in its payload
+    if (!options?.skipConfigurationCall) {
+      handleEtrustedConfiguration(
+        token,
+        selectAllState(get()),
+        'trustbadge',
+        putEtrustedConfiguration,
+      )
+    }
   },
 
   clearStructuredMarkupState: () => {

--- a/src/store/structuredMarkup/types.ts
+++ b/src/store/structuredMarkup/types.ts
@@ -10,6 +10,9 @@ export interface IStructuredMarkupStore {
   setStructuredMarkupEnabled: (value: boolean) => void
   setStructuredMarkupLoading: (value: boolean) => void
   getStructuredMarkupConfiguration: (channel: IMappedChannel) => void
-  updateStructuredMarkupEnabled: (enabled: boolean) => void
+  updateStructuredMarkupEnabled: (
+    enabled: boolean,
+    options?: { skipConfigurationCall?: boolean },
+  ) => void
   clearStructuredMarkupState: () => void
 }


### PR DESCRIPTION
- Add structuredMarkupState to selectAllState and getFreshAllState payloads (gated on allowsSupportStructuredMarkup)
- Trigger the configuration call when toggling structured markup
- Send a single configuration call on trustbadge deactivation carrying both the disabled trustbadge and the disabled markup state

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
<!--
Relates OR Closes #0000
-->

## Description
<!-- Short description about the change, what have you done? -->
