### PR TITLE
feat: Show loader while structured markup save awaits shop system res…

### DIFF
--- a/src/eventsContainer/index.tsx
+++ b/src/eventsContainer/index.tsx
@@ -38,6 +38,7 @@ const EventsContainer: FC<{ children: VNode }> = ({ children }) => {
     setTrstdLoginLocations,
     setTrstdLoginLoadingBL,
     setStructuredMarkupEnabled,
+    setStructuredMarkupLoading,
   } = useStore()
 
   useEffect(() => {
@@ -162,6 +163,7 @@ const EventsContainer: FC<{ children: VNode }> = ({ children }) => {
     setIsLoadingInvitesForProducts(false)
     setIsAuthLoading(false)
     setTrstdLoginLoadingBL(false)
+    setStructuredMarkupLoading(false)
   }
 
   return children

--- a/src/store/structuredMarkup/index.ts
+++ b/src/store/structuredMarkup/index.ts
@@ -65,8 +65,19 @@ export const structuredMarkupStore = (
     const { selectedShopChannels } = state.channelState
     const { trustbadgeId } = state.trustbadgeState
     const token = state.auth.user?.access_token
+    const supportsStructuredMarkupEvents = !!EVENTS.SAVE_STRUCTURED_MARKUP_CONFIGURATION
 
-    if (EVENTS.SAVE_STRUCTURED_MARKUP_CONFIGURATION) {
+    // loading stays on until the shop system confirms the save via
+    // SET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED (handled in eventsContainer)
+    set(store => ({
+      structuredMarkupState: {
+        ...store.structuredMarkupState,
+        structuredMarkupEnabled: enabled,
+        isLoadingStructuredMarkup: supportsStructuredMarkupEvents,
+      },
+    }))
+
+    if (supportsStructuredMarkupEvents) {
       dispatchAction({
         action: EVENTS.SAVE_STRUCTURED_MARKUP_CONFIGURATION,
         payload: {
@@ -77,13 +88,6 @@ export const structuredMarkupStore = (
         },
       })
     }
-
-    set(store => ({
-      structuredMarkupState: {
-        ...store.structuredMarkupState,
-        structuredMarkupEnabled: enabled,
-      },
-    }))
 
     // skipped when the caller sends its own configuration call afterwards,
     // e.g. trustbadge deactivation which already includes the updated


### PR DESCRIPTION
…ponse

Toggling the structured markup switch now keeps the spinner visible until the shop system confirms via SET_STRUCTURED_MARKUP_CONFIGURATION_PROVIDED or reports a failure through a notification event (closeAllLoadings).

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
<!--
Relates OR Closes #0000
-->

## Description
<!-- Short description about the change, what have you done? -->
